### PR TITLE
references #21 of the original repository. a directive looks wrong

### DIFF
--- a/src/coffee/mobile-angular-ui-scrollable-iscroll-lite.coffee
+++ b/src/coffee/mobile-angular-ui-scrollable-iscroll-lite.coffee
@@ -34,12 +34,12 @@
     replace: false
     restrict: "C"
     link: (scope, element, attr) ->
-    adjustScrollableHeight(element.parent()[0])
-    setTimeout (->
-      [].slice.call(document.querySelectorAll("input, select, button, textarea")).forEach (el) ->
-        el.addEventListener (if ("ontouchstart" of window) then "touchstart" else "mousedown"), (e) ->
-          e.stopPropagation()
-   
-      iscroll = new IScroll(element[0], {checkDOMChanges: true})
-    ), 200
+      adjustScrollableHeight(element.parent()[0])
+      setTimeout (->
+        [].slice.call(document.querySelectorAll("input, select, button, textarea")).forEach (el) ->
+          el.addEventListener (if ("ontouchstart" of window) then "touchstart" else "mousedown"), (e) ->
+            e.stopPropagation()
+     
+        iscroll = new IScroll(element[0], {checkDOMChanges: true})
+      ), 200
 )()

--- a/src/coffee/mobile-angular-ui-scrollable-iscroll.coffee
+++ b/src/coffee/mobile-angular-ui-scrollable-iscroll.coffee
@@ -34,12 +34,12 @@
     replace: false
     restrict: "C"
     link: (scope, element, attr) ->
-    adjustScrollableHeight(element.parent()[0])
-    setTimeout (->
-      [].slice.call(document.querySelectorAll("input, select, button, textarea")).forEach (el) ->
-        el.addEventListener (if ("ontouchstart" of window) then "touchstart" else "mousedown"), (e) ->
-          e.stopPropagation()
- 
-      iscroll = new IScroll(element[0], {scrollbars: true, mouseWheel:true, checkDOMChanges: true})
-    ), 200
+      adjustScrollableHeight(element.parent()[0])
+      setTimeout (->
+        [].slice.call(document.querySelectorAll("input, select, button, textarea")).forEach (el) ->
+          el.addEventListener (if ("ontouchstart" of window) then "touchstart" else "mousedown"), (e) ->
+            e.stopPropagation()
+   
+        iscroll = new IScroll(element[0], {scrollbars: true, mouseWheel:true, checkDOMChanges: true})
+      ), 200
 )()


### PR DESCRIPTION
This PR references #21

The coffee code looked wrong. it generates an empty link function and doesn't respect the syntax of the directive.

Compare the original generated code:

```
directive("scrollableContent", function() {
    ({
      replace: false,
      restrict: "C",
      link: function(scope, element, attr) {}
    });
    adjustScrollableHeight(element.parent()[0]);
    return setTimeout((function() {
      var iscroll;
      [].slice.call(document.querySelectorAll("input, select, button, textarea")).forEach(function(el) {
        return el.addEventListener(("ontouchstart" in window ? "touchstart" : "mousedown"), function(e) {
          return e.stopPropagation();
        });
      });
      return iscroll = new IScroll(element[0], {
        checkDOMChanges: true
      });
    }), 200);
  });
```

and the new generated code:

```
directive("scrollableContent", function() {
    return {
      replace: false,
      restrict: "C",
      link: function(scope, element, attr) {
        adjustScrollableHeight(element.parent()[0]);
        return setTimeout((function() {
          var iscroll;
          [].slice.call(document.querySelectorAll("input, select, button, textarea")).forEach(function(el) {
            return el.addEventListener(("ontouchstart" in window ? "touchstart" : "mousedown"), function(e) {
              return e.stopPropagation();
            });
          });
          return iscroll = new IScroll(element[0], {
            checkDOMChanges: true
          });
        }), 200);
      }
    };
  });
```

In the original generated code, `element`of  `adjustScrollableHeight(element.parent()[0]);` is undefined. the rest of the code does not follow the definition of a directive.

this PR is fixing the error and generates a correct directive, at least from my point of view.
However, I can't get firefox to scroll properly.
It does work with overthrow, though.
