### PR TITLE
Fixed site build and demo link

### DIFF
--- a/Gruntfile.coffee
+++ b/Gruntfile.coffee
@@ -170,7 +170,7 @@ module.exports = (grunt) ->
         options:
           hostname: '0.0.0.0'
           port: 3000
-          base: 'site/output'
+          base: ['site/output', '.']
           keepalive: true
 
     githubPages:

--- a/site/Rules
+++ b/site/Rules
@@ -36,6 +36,7 @@ compile '/sitemap/' do
   # don’t filter or layout
 end
 
+=begin
 compile '/docs/' do
   filter :relativize_paths, :type => :html
   filter :erb
@@ -43,6 +44,7 @@ compile '/docs/' do
   filter :colorize_syntax, :default_colorizer => :pygmentsrb
   layout 'docs'
 end
+=end
 
 compile '*' do
   if item.binary?


### PR DESCRIPTION
Site build is barfing due to empty docs, commented out.
Demo link needs code root to be accessible over the web.
