### PR TITLE
Enhancements to the switch directive

### DIFF
--- a/src/js/lib/forms.js
+++ b/src/js/lib/forms.js
@@ -77,19 +77,13 @@ angular.module('mobile-angular-ui.directives.forms', [])
       changeExpr: "@ngChange",
       disabled: "@"
     },
-    template: "<div class='switch'><div class='switch-handle'></div></div>",
+    template: "<div class='switch' ng-class='{active: model}'><div class='switch-handle'></div></div>",
     link: function(scope, elem, attrs) {
-
-      function updateClass(model) {
-        if (model) { elem.addClass('active'); } else { elem.removeClass('active'); }
-      }
-
-      updateClass(scope.model);
 
       elem.on('click tap', function(){
         if (attrs.disabled == null) {
           scope.model = !scope.model;
-          updateClass(scope.model);
+          scope.$apply();
 
           if (scope.changeExpr != null) {
             scope.$parent.$eval(scope.changeExpr);


### PR DESCRIPTION
I stumbled upon some complications using the switch directive as it is described in the documentation (`<switch ng-model="invoice.paid"></switch>`). Changes to the ngModel aren't reflected in the _parent_ scope, if the ngClick-attribute isn't specified. So manually applying the ngModel-changes via `scope.$apply` did solve this issue in my case.
Additionally external changes to the linked ngModel (e.g. through a additional checkbox) aren't handled by the directive. By linking the ngModel directly via ngClass the style and the ngModel's value stay in sync.
