### PR TITLE
fix #82, hide the right sidebar

### DIFF
--- a/src/less/lib/sidebar.less
+++ b/src/less/lib/sidebar.less
@@ -4,7 +4,7 @@
   top: 0;
   bottom: 0;
   display: block;
-  
+
   .translate3d(0, 0, 0);
   .transition-transform(~"400ms ease");
 }
@@ -30,6 +30,7 @@
   z-index: -100;
   .opacity(0);
   .transition(~"opacity  600ms cubic-bezier(1, 0, 1, 0), width 400ms ease");
+  width: 0;
 }
 
 .sidebar-left-in .app {


### PR DESCRIPTION
The right sidebar (chat group) was covering the left sidebar. Setting the width of the right sidebar to 0 solved the problem when I tested it.
I have only tested it on the iOS simulator.
