### PR TITLE
Removed unused npm dependency: kexec

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "grunt-contrib-watch": "~0.5.3",
     "grunt-recess": "~0.6.1",
     "less": "~1.4.2",
-    "kexec": "~0.1.1",
     "parameterize": "0.0.7",
     "grunt-github-pages": "0.0.4",
     "semver": "~2.2.1",


### PR DESCRIPTION
- it won't build on a windows system without visual studio
- it doesn't work on a windows system
- it's unused in the project.
