### PR TITLE
Better way to find child elements of carousel.

### DIFF
--- a/src/js/lib/carousel.js
+++ b/src/js/lib/carousel.js
@@ -11,8 +11,8 @@ angular.module('mobile-angular-ui.directives.carousel', [])
     };
     
     var carouselItems = function(id) {
-      var elem = angular.element(document.getElementById(id));
-      var res = angular.element(elem.children()[0]).children();
+      var elem = angular.element(document.getElementById(id).getElementsByClassName('carousel-inner'));
+      var res = angular.element(elem.children());
       elem = null;
       return res;
     };


### PR DESCRIPTION
I ran into this problem when I added prev and next buttons markup between the id="carousel" and class="carousel-inner" tags.