### PR TITLE
Fixed implicitly defined variable which was firing errors on IE 9,10,11

### DIFF
--- a/dist/js/mobile-angular-ui.js
+++ b/dist/js/mobile-angular-ui.js
@@ -1328,9 +1328,16 @@ angular.module('mobile-angular-ui.fastclick', [])
 
 .run([
   '$window', '$document', function($window, $document) {
-    $window.addEventListener("load", (function() {
-       FastClick.attach($document[0].body);
-    }), false);
+    if ($window.addEventListener) {
+      $window.addEventListener("load", (function () {
+        FastClick.attach($document[0].body);
+      }), false);
+    }
+    else {
+      $window.attachEvent("load", (function () {
+        FastClick.attach($document[0].body);
+      }), false);
+    }
   }
 ])
 


### PR DESCRIPTION
This was causing issues on some IE versions, or at least the ones I was testing my app on: 9, 10, 11 .
Hope it helps.
