### PR TITLE
FIX for directives navbarAbsoluteTop & navbarAbsoluteBottom in combination with directive ngIf

### DIFF
--- a/src/js/lib/navbars.js
+++ b/src/js/lib/navbars.js
@@ -6,6 +6,9 @@ angular.module('mobile-angular-ui.directives.navbars', [])
     restrict: "C",
     link: function(scope, elem, attrs) {
       elem.parent().addClass('has-navbar-top');
+      elem.bind("$destroy", function() {
+            elem.parent().removeClass('has-navbar-top');
+        });
     }
   };
 })
@@ -16,6 +19,9 @@ angular.module('mobile-angular-ui.directives.navbars', [])
     restrict: "C",
     link: function(scope, elem, attrs) {
       elem.parent().addClass('has-navbar-bottom');
+      elem.bind("$destroy", function() {
+            elem.parent().removeClass('has-navbar-bottom');
+        });
     }
   };
 });


### PR DESCRIPTION
In case of directive ngIf (dynamic add/remove of navbars) the parent classes of navbars should be updated correctly (remove classes has-navbar-top / has-navbar-bottom)