### PR TITLE
interpret variables in toggle/turn-on/turn-off directive attribute values

### DIFF
--- a/src/js/core/ui.js
+++ b/src/js/core/ui.js
@@ -48,15 +48,12 @@
               return {
                 restrict: 'A',
                 compile: function(elem, attrs) {
-                  var fn = methodName === 'set' ?
-                    $parse(attrs[directiveName]) :
-                      function(scope) {
-                        return attrs[directiveName]; 
-                      };
 
                   return function(scope, elem, attrs) {
                     var callback = function() {
-                      var arg = fn(scope);
+                      var arg = methodName === 'set' ?
+                      $parse(attrs[directiveName])(scope) :
+                      attrs[directiveName];
                       return method.call(SharedState, arg);
                     };
                     uiBindEvent(scope, elem, attrs.uiTriggers, callback);


### PR DESCRIPTION
this allows for dynamic values, including in nested scopes, e.g. an ng-repeat loop containing multiple dropdown buttons

I've added an example with multiple dropdown buttons in an `ng-repeat` loop and compiled files to this release branch:
https://github.com/PortChaw/mobile-angular-ui/tree/multiple-dropdowns-release

Specifically, example is here:
https://github.com/PortChaw/mobile-angular-ui/blob/multiple-dropdowns-release/demo/dropdown.html#L38