### PR TITLE
Fix missing styling of input type "password"

### DIFF
--- a/src/less/lib/forms.less
+++ b/src/less/lib/forms.less
@@ -6,6 +6,7 @@ input[type="number"],
 input[type="search"],
 input[type="tel"],
 input[type="text"],
+input[type="password"],
 input[type="url"] {
   -webkit-appearance: none;
 }


### PR DESCRIPTION
On iOS 8.1.1 in Safari the password input field had a shadow. This did not occur on desktop Safari for WIndows.