### PR TITLE
Allow nested property names in uiScopeContext, using dot notation in Strings

### DIFF
--- a/src/js/core/sharedState.js
+++ b/src/js/core/sharedState.js
@@ -740,7 +740,9 @@
     for (var i = 0; i < scopeVars.length; i++) {
       var key = scopeVars[i][0];
       var alias = scopeVars[i][1] || key;
-      context[alias] = scope[key];
+      context[alias] = key.split('.').reduce(function (scope, nextKey) {
+        return scope[nextKey];
+      }, scope);
     }
   };
 

--- a/test/core/sharedstate-ui-cond.test.html
+++ b/test/core/sharedstate-ui-cond.test.html
@@ -4,6 +4,7 @@
       app.run(function($rootScope, SharedState) {
         $rootScope.trueVar = true;
         $rootScope.falseVar = false;
+        $rootScope.nested = { trueProp: true };
         SharedState.initialize($rootScope, 'testState', {defaultValue: true});
       });
     </script>
@@ -28,6 +29,7 @@
     <div id="uiScopeContextUi3" ui-show="falseVar || testState" ui-scope-context='falseVar'>uiScopeContextUi3</div>
     <div id="uiScopeContextUi4" ui-hide="myVar || testState" ui-scope-context='falseVar as myVar'>uiScopeContextUi4</div>
     <div id="uiScopeContextUi5" ui-class="{'active': !myVar && trueVar}" ui-scope-context='trueVar, falseVar as myVar'>uiScopeContextUi5</div>
+    <div id='uiScopeContextUi6' ui-hide="trueVar" ui-scope-context="nested.trueProp as trueVar"></div>
 
   </body>
 
@@ -48,6 +50,7 @@
     expect($('#uiScopeContextUi3').isDisplayed()).toBe(true);
     expect($('#uiScopeContextUi4').isDisplayed()).toBe(false);
     expect($('#uiScopeContextUi5')).toHaveClass('active');
+    expect($('#uiScopeContextUi6').isDisplayed()).toBe(false);
   </script>
 
 </html>


### PR DESCRIPTION
uiScopeContext as it is right now can only properly evaluate variables directly bound to the scope.

This makes it incompatible with the controllerAs way of doing things which is largely promoted by the Angular core team and is widely regarded as the 'correct way going forward', most notably for apps which will be migrated to Angular 2.

When using controllerAs, we define a name which will represent the controller (through its `this` in the template).

```javascript
function MyController () {
  this.myProp = true;
}
// ...
controllerAs: ctrl
```

We can then use it like this (or should be able to :wink: ) :
```html
<div> {{ ctrl.myProp }} </div>
<div ui-if="myProp == true" ui-scope-context="ctrl.myProp as myProp"></div>
```

What this PR does is enable the latter use through the use of reduce instead of a direct property accessor. I felt free to use `Array.prototype.reduce` as it is implemented in every browser mobile-angular-ui supports (and even IE9).

I added a test to reflect this new functionality.