### PR TITLE
Bugfix: Assign noop correctly to allow switch to be properly destroyed

### DIFF
--- a/src/js/components/switch.js
+++ b/src/js/components/switch.js
@@ -104,7 +104,7 @@
 
         elem.on('click tap', clickCb);
 
-        var unbind = angular.noop();
+        var unbind = angular.noop;
 
         if ($drag) {
           unbind = $drag.bind(handle, {


### PR DESCRIPTION
$destroy event on the uiSwitch would cause a 'undefined is not a function' exception because of this error in a noop attribution when not using $drag.

This happens for example when the uiSwitch is under an ngIf that gets toggled on and off, and then breaks the other directives in the same component.