### PR TITLE
Fix display table in Firefox

### DIFF
--- a/src/less/lib/justified.less
+++ b/src/less/lib/justified.less
@@ -3,6 +3,7 @@
 .justified {
   display: table;
   width: 100%;
+  table-layout: fixed;
   > * {
     display: table-cell;
     width: 1%;


### PR DESCRIPTION
Justified table is not properly rendered in Firefox

See http://www.carsonshold.com/2014/07/css-display-table-cell-child-width-bug-in-firefox-and-ie/