### PR TITLE
Remove moot `version` property from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,6 @@
   "authors": [
     "mcasimir <maurizio.cas@gmail.com>"
   ],
-  "version": "1.2.0",
   "description": "Mobile UI for Bootstrap 3 and Angular JS",
   "main": [
     "dist/css/mobile-angular-ui-hover.css",


### PR DESCRIPTION
Per bower/bower.json-spec@a325da3

Also their maintainer says they probably won't ever use it: http://stackoverflow.com/questions/24844901/bowers-bower-json-file-version-property