### PR TITLE
Allow multiple ui-content-for for one ui-yield-to

### DIFF
--- a/src/js/core/capture.js
+++ b/src/js/core/capture.js
@@ -164,7 +164,7 @@
            if (!b) {
              return;
            }
-           b.element.html(content);
+           b.element.html(b.element.html() + content);
            $compile(b.element.contents())(scope);
          }
 


### PR DESCRIPTION
There are cases when you want having different `ui-content-for` for the same `ui-yield-to`. An example is having `<div ui-yield-to="modals"></div>` and defining two modals in different templates.

Currently, only one modal is shown

My concern with this patch is the `$compile` function. Should it be called twice on the same content?