### PR TITLE
Implement workaround for jQuery event normalization

### DIFF
--- a/src/js/core/touchmoveDefaults.js
+++ b/src/js/core/touchmoveDefaults.js
@@ -47,7 +47,9 @@
 
   module.directive('uiPreventTouchmoveDefaults', function() {
     var preventTouchmoveDefaultsCb = function(e) {
-      if (e.allowTouchmoveDefault !== true) {
+      // Get this flag from either the saved event if jQuery is being used, otherwise get it from the event itself.
+      var allowTouchmoveEventFlag = e.originalEvent ? e.originalEvent.allowTouchmoveDefault : e.allowTouchmoveDefault;
+      if (allowTouchmoveEventFlag !== true) {
         e.preventDefault();
       }
     };
@@ -95,7 +97,11 @@
           condition = condition || fnTrue;
 
           var allowTouchmoveDefaultCallback = function(e) {
-            if (condition(e)) { e.allowTouchmoveDefault = true; }
+            if (condition(e)) {
+              e.allowTouchmoveDefault = true;
+              // jQuery normalizes the event object, need to put this property on the copied originalEvent.
+              if (e.originalEvent) e.originalEvent.allowTouchmoveDefault = true;
+            }
           };
 
           $element = angular.element($element);

--- a/src/js/core/touchmoveDefaults.js
+++ b/src/js/core/touchmoveDefaults.js
@@ -100,7 +100,9 @@
             if (condition(e)) {
               e.allowTouchmoveDefault = true;
               // jQuery normalizes the event object, need to put this property on the copied originalEvent.
-              if (e.originalEvent) e.originalEvent.allowTouchmoveDefault = true;
+              if (e.originalEvent) {
+                e.originalEvent.allowTouchmoveDefault = true;
+              }
             }
           };
 


### PR DESCRIPTION
See discussions in issues #311 and #298.

I implemented the suggested fix by @sudiptaangular.

Without this fix, you can't use jQuery with Angular and instead have to fall back to jqLite. jQuery normalizes the event object to match the W3C spec, so any added fields get removed. There is the "originalEvent" object that can work for this.

Legal: I give full permission to use this code in any way.