### PR TITLE
Fix activeLinks, when the url is not index

### DIFF
--- a/src/js/core/activeLinks.js
+++ b/src/js/core/activeLinks.js
@@ -50,6 +50,9 @@
 
               var html5Mode = $locationProvider.html5Mode().enabled;
               if (!html5Mode) {
+              	if (href.split("#") && href.split("#").length > 1) {
+              		href = "#" + href.split("#")[1];
+              	}                
                 var linkPrefix = '#' + $locationProvider.hashPrefix();
                 if (href.slice(0, linkPrefix.length) === linkPrefix) {
                   href = href.slice(linkPrefix.length);


### PR DESCRIPTION
A route can be, /accounting/generals/#/ticket", then It won't be recognized by activeLinks.
But with this three lines, it will work.
It happens, because I'm trying mobile-angular-ui in desktop browser.